### PR TITLE
refactor: move main reducer to own file, add tests

### DIFF
--- a/challenge-react/src/__tests__/actions.test.js
+++ b/challenge-react/src/__tests__/actions.test.js
@@ -4,7 +4,7 @@ describe('setMessage', () => {
   test('should create action with correct type and message', () => {
     const message = 'Thank you for your donation';
     expect(actions.setMessage(message)).toMatchObject({
-      type: 'UPDATE_MESSAGE',
+      type: 'SET_MESSAGE',
       message,
     });
   });

--- a/challenge-react/src/__tests__/reducers.test.js
+++ b/challenge-react/src/__tests__/reducers.test.js
@@ -1,0 +1,124 @@
+import { mainReducer } from '../reducers';
+
+describe('mainReducer', () => {
+  describe('should return correctly updated new version of state', () => {
+    const baseState = {
+      message: '',
+      charities: [],
+      payments: [],
+      error: null,
+    };
+
+    const charities = [
+      {
+        id: 1,
+        name: 'Baan Kru Noi',
+        image: 'baan-kru-noi.jpg',
+        currency: 'THB',
+      },
+      {
+        id: 2,
+        name: 'Habitat for Humanity Thailand',
+        image: 'habitat-for-humanity-thailand.jpg',
+        currency: 'THB',
+      },
+      {
+        id: 3,
+        name: 'Paper Ranger',
+        image: 'paper-ranger.jpg',
+        currency: 'THB',
+      },
+    ];
+
+    const payments = [
+      {
+        charitiesId: 2,
+        amount: 10,
+        currency: 'THB',
+        id: 1,
+      },
+      {
+        charitiesId: 1,
+        amount: 20,
+        currency: 'THB',
+        id: 2,
+      },
+      {
+        charitiesId: 3,
+        amount: 50,
+        currency: 'THB',
+        id: 3,
+      },
+    ];
+
+    const error = {
+      title: 'An error has occurred',
+      message: 'Do not panic, help is on the way.',
+      original: new Error('FAKE: Error in processing'),
+    };
+
+    test('setMessage', () => {
+      const message =
+        'Thank you for donating 50 THB to Habitat for Humanity Thailand';
+      const nextState = mainReducer(baseState, {
+        type: 'SET_MESSAGE',
+        message,
+      });
+      expect(nextState).toMatchObject({ ...baseState, message });
+    });
+
+    test('setCharities', () => {
+      const nextState = mainReducer(baseState, {
+        type: 'SET_CHARITIES',
+        charities,
+      });
+      expect(nextState).toMatchObject({ ...baseState, charities });
+    });
+
+    test('setPayments', () => {
+      const nextState = mainReducer(baseState, {
+        type: 'SET_PAYMENTS',
+        payments,
+      });
+      expect(nextState.payments).toMatchObject(payments);
+    });
+
+    test('addPayment', () => {
+      const stateWithPayments = { ...baseState, payments };
+      const addedPayment = {
+        charitiesId: 4,
+        amount: 10,
+        currency: 'THB',
+        id: 4,
+      };
+
+      const nextState = mainReducer(stateWithPayments, {
+        type: 'ADD_PAYMENT',
+        payment: addedPayment,
+      });
+      expect(nextState.payments).toMatchObject([...payments, addedPayment]);
+    });
+
+    test('setError', () => {
+      const nextState = mainReducer(baseState, { type: 'SET_ERROR', error });
+      expect(nextState).toMatchObject({ ...baseState, error });
+    });
+
+    test('setError (to null)', () => {
+      const stateWithError = { ...baseState, error };
+
+      const nextState = mainReducer(stateWithError, {
+        type: 'SET_ERROR',
+        error: null,
+      });
+      expect(nextState).toMatchObject({ ...baseState, error: null });
+    });
+
+    test('invalid actionType should return state as-is', () => {
+      const title = 'please make merit';
+
+      const nextState = mainReducer(baseState, { type: 'SET_TITLE', title });
+      expect(Object.is(nextState, baseState)).toBe(true);
+    });
+  });
+});

--- a/challenge-react/src/actions.js
+++ b/challenge-react/src/actions.js
@@ -1,5 +1,5 @@
 export const actionTypes = {
-  setMessage: 'UPDATE_MESSAGE',
+  setMessage: 'SET_MESSAGE',
   setCharities: 'SET_CHARITIES',
   setPayments: 'SET_PAYMENTS',
   addPayment: 'ADD_PAYMENT',

--- a/challenge-react/src/components/App.jsx
+++ b/challenge-react/src/components/App.jsx
@@ -47,6 +47,7 @@ export const App = () => {
       })
       .catch((error) => {
         dispatch(
+          // TODO: l10n
           actions.setError({
             title: 'Could not get Charities',
             message: 'An error occurred while trying to get list of charities',
@@ -64,6 +65,7 @@ export const App = () => {
         dispatch(actions.setPayments(payments));
       })
       .catch((error) => {
+        // TODO: l10n
         dispatch(
           actions.setError({
             title: 'Could not get Payments',

--- a/challenge-react/src/index.jsx
+++ b/challenge-react/src/index.jsx
@@ -3,41 +3,9 @@ import { render } from 'react-dom';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
 import { App } from './components/App.jsx';
-import { actionTypes } from './actions';
+import {rootReducer} from './reducers';
 
-const store = createStore((state, action) => {
-  const _state =
-    state == null
-      ? {
-          message: '',
-          charities: [],
-          payments: [],
-          error: null,
-        }
-      : state;
-
-  switch (action.type) {
-
-    case actionTypes.setMessage:
-      return { ..._state, message: action.message };
-
-    case actionTypes.setCharities:
-      return {..._state, charities: action.charities };
-
-    case actionTypes.setPayments:
-      return {..._state, payments: action.payments };
-
-    case actionTypes.addPayment:
-      const payments = [..._state.payments, action.payment];
-      return {..._state, payments};
-
-    case actionTypes.setError:
-      return {..._state, error: action.error}
-
-    default:
-      return _state;
-  }
-});
+const store = createStore(rootReducer)
 
 render(
   <Provider store={store}>

--- a/challenge-react/src/reducers.js
+++ b/challenge-react/src/reducers.js
@@ -1,0 +1,34 @@
+import { actionTypes } from './actions';
+
+export const mainReducer = (state, action) => {
+  const _state =
+    state == null
+      ? {
+          message: '',
+          charities: [],
+          payments: [],
+          error: null,
+        }
+      : state;
+
+  switch (action.type) {
+    case actionTypes.setMessage:
+      return { ..._state, message: action.message };
+
+    case actionTypes.setCharities:
+      return { ..._state, charities: action.charities };
+
+    case actionTypes.setPayments:
+      return { ..._state, payments: action.payments };
+
+    case actionTypes.addPayment:
+      const payments = [..._state.payments, action.payment];
+      return { ..._state, payments };
+
+    case actionTypes.setError:
+      return { ..._state, error: action.error };
+
+    default:
+      return _state;
+  }
+};


### PR DESCRIPTION
### Changes

- move main reducer logic to its own file
- add tests for main reducer
- rename `SET_MESSAGE` actionType for clarity and consistency