### PR TITLE
restore modal scrim styling

### DIFF
--- a/challenge-react/public/css/main.css
+++ b/challenge-react/public/css/main.css
@@ -64,6 +64,9 @@
   height: 100%;
   top: 0;
   left: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   justify-content: flex-start;
 }
 


### PR DESCRIPTION
In a previous PR I accidentally deleted the centering styling for the modal.

Here I've fixed that.