### PR TITLE
fix: can't load production built file from dist folder

### DIFF
--- a/challenge-react/public/index.html
+++ b/challenge-react/public/index.html
@@ -15,6 +15,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="/dist/main.js"></script>
+    <script src="../dist/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
I probably should have tried building and running the "production" bundle before now. 😅
The link URL for the bundle didn't work as is, so I've updated it.